### PR TITLE
New role for ChatMessage + Reordering of existing roles

### DIFF
--- a/volapi/chat.py
+++ b/volapi/chat.py
@@ -163,7 +163,7 @@ class ChatMessage(str):
 
     @property
     def green(self):
-        return self.user
+        return self.user and not self.purple
 
     @property
     def staff(self):

--- a/volapi/chat.py
+++ b/volapi/chat.py
@@ -9,6 +9,7 @@ class Roles(Enum):
     WHITE = "white"
     USER = "green"
     PRO = "pro"
+    OWNER = "owner"
     JANITOR = "janitor"
     DONOR = "donor"
     STAFF = "trusted user"
@@ -23,10 +24,12 @@ class Roles(Enum):
                 return cls.ADMIN
             if "staff" in options:
                 return cls.STAFF
-            if "pro" in options:
-                return cls.PRO
+            if "owner" in options:
+                return cls.OWNER
             if "janitor" in options:
                 return cls.JANITOR
+            if "pro" in options:
+                return cls.PRO
             if "donator" in options:
                 return cls.DONOR
             if "user" in options:
@@ -145,6 +148,10 @@ class ChatMessage(str):
         return self.role is Roles.PRO
 
     @property
+    def owner(self):
+        return self.role is Roles.OWNER
+
+    @property
     def janitor(self):
         return self.role is Roles.JANITOR
 
@@ -154,7 +161,7 @@ class ChatMessage(str):
 
     @property
     def green(self):
-        return self.pro or self.donor or self.user or self.janitor
+        return self.pro or self.donor or self.user or self.janitor or self.owner
 
     @property
     def staff(self):
@@ -188,6 +195,8 @@ class ChatMessage(str):
             prefix += "@"
         if self.pro:
             prefix += "✡"
+        if self.owner:
+            prefix += "👑"
         if self.janitor:
             prefix += "🧹"
         if self.donor:

--- a/volapi/chat.py
+++ b/volapi/chat.py
@@ -18,29 +18,29 @@ class Roles(Enum):
 
     @classmethod
     def from_options(cls, options):
-        role_list = []
+        role_set = set()
         user = "profile" in options
         if user:
             if "admin" in options:
-                role_list.append(cls.ADMIN)
+                role_set.add(cls.ADMIN)
             if "staff" in options:
-                role_list.append(cls.STAFF)
+                role_set.add(cls.STAFF)
             if "owner" in options:
-                role_list.append(cls.OWNER)
+                role_set.add(cls.OWNER)
             if "janitor" in options:
-                role_list.append(cls.JANITOR)
+                role_set.add(cls.JANITOR)
             if "pro" in options:
-                role_list.append(cls.PRO)
+                role_set.add(cls.PRO)
             if "donator" in options:
-                role_list.append(cls.DONOR)
+                role_set.add(cls.DONOR)
             if "user" in options:
-                role_list.append(cls.USER)
+                role_set.add(cls.USER)
         else:
             if "admin" in options or "staff" in options:
-                role_list.append(cls.SYSTEM)
-            else:
-                role_list.append(cls.WHITE)
-        return role_list
+                role_set.add(cls.SYSTEM)
+        if not role_set:
+            role_set.add(cls.WHITE)
+        return role_set
 
     def __str__(self):
         return self.value
@@ -58,15 +58,15 @@ class ChatMessage(str):
 
     # pylint: disable=no-member
 
-    def __new__(cls, room, conn, nick, msg, role=[Roles.WHITE], options=None, **kw):
-        for entry in role:
+    def __new__(cls, room, conn, nick, msg, roles={Roles.WHITE}, options=None, **kw):
+        for entry in roles:
             if entry not in Roles:
                 raise ValueError("Invalid role")
         obj = super().__new__(cls, msg)
         obj.room = room
         obj.conn = conn
         obj.nick = nick
-        obj.role = role
+        obj.roles = roles
         obj.options = options or dict()
 
         # Optionals
@@ -120,7 +120,7 @@ class ChatMessage(str):
             conn,
             nick,
             msg,
-            role=Roles.from_options(options),
+            roles=Roles.from_options(options),
             options=options,
             data=data,
             files=files,
@@ -139,27 +139,27 @@ class ChatMessage(str):
 
     @property
     def white(self):
-        return Roles.WHITE in self.role
+        return Roles.WHITE in self.roles
 
     @property
     def user(self):
-        return Roles.USER in self.role
+        return Roles.USER in self.roles
 
     @property
     def pro(self):
-        return Roles.PRO in self.role
+        return Roles.PRO in self.roles
 
     @property
     def owner(self):
-        return Roles.OWNER in self.role
+        return Roles.OWNER in self.roles
 
     @property
     def janitor(self):
-        return Roles.JANITOR in self.role
+        return Roles.JANITOR in self.roles
 
     @property
     def donor(self):
-        return Roles.DONOR in self.role
+        return Roles.DONOR in self.roles
 
     @property
     def green(self):
@@ -167,11 +167,11 @@ class ChatMessage(str):
 
     @property
     def staff(self):
-        return Roles.STAFF in self.role
+        return Roles.STAFF in self.roles
 
     @property
     def admin(self):
-        return Roles.ADMIN in self.role
+        return Roles.ADMIN in self.roles
 
     @property
     def purple(self):
@@ -179,7 +179,7 @@ class ChatMessage(str):
 
     @property
     def system(self):
-        return Roles.SYSTEM in self.role
+        return Roles.SYSTEM in self.roles
 
     @property
     def logged_in(self):

--- a/volapi/chat.py
+++ b/volapi/chat.py
@@ -18,28 +18,29 @@ class Roles(Enum):
 
     @classmethod
     def from_options(cls, options):
+        role_list = []
         user = "profile" in options
         if user:
             if "admin" in options:
-                return cls.ADMIN
+                role_list.append(cls.ADMIN)
             if "staff" in options:
-                return cls.STAFF
+                role_list.append(cls.STAFF)
             if "owner" in options:
-                return cls.OWNER
+                role_list.append(cls.OWNER)
             if "janitor" in options:
-                return cls.JANITOR
+                role_list.append(cls.JANITOR)
             if "pro" in options:
-                return cls.PRO
+                role_list.append(cls.PRO)
             if "donator" in options:
-                return cls.DONOR
+                role_list.append(cls.DONOR)
             if "user" in options:
-                return cls.USER
+                role_list.append(cls.USER)
         else:
-            if "admin" in options:
-                return cls.SYSTEM
-            if "staff" in options:
-                return cls.SYSTEM
-        return cls.WHITE
+            if "admin" in options or "staff" in options:
+                role_list.append(cls.SYSTEM)
+            else:
+                role_list.append(cls.WHITE)
+        return role_list
 
     def __str__(self):
         return self.value
@@ -57,9 +58,10 @@ class ChatMessage(str):
 
     # pylint: disable=no-member
 
-    def __new__(cls, room, conn, nick, msg, role=Roles.WHITE, options=None, **kw):
-        if role not in Roles:
-            raise ValueError("Invalid role")
+    def __new__(cls, room, conn, nick, msg, role=[Roles.WHITE], options=None, **kw):
+        for entry in role:
+            if entry not in Roles:
+                raise ValueError("Invalid role")
         obj = super().__new__(cls, msg)
         obj.room = room
         obj.conn = conn
@@ -137,39 +139,39 @@ class ChatMessage(str):
 
     @property
     def white(self):
-        return self.role is Roles.WHITE
+        return Roles.WHITE in self.role
 
     @property
     def user(self):
-        return self.role is Roles.USER
+        return Roles.USER in self.role
 
     @property
     def pro(self):
-        return self.role is Roles.PRO
+        return Roles.PRO in self.role
 
     @property
     def owner(self):
-        return self.role is Roles.OWNER
+        return Roles.OWNER in self.role
 
     @property
     def janitor(self):
-        return self.role is Roles.JANITOR
+        return Roles.JANITOR in self.role
 
     @property
     def donor(self):
-        return self.role is Roles.DONOR
+        return Roles.DONOR in self.role
 
     @property
     def green(self):
-        return self.pro or self.donor or self.user or self.janitor or self.owner
+        return self.user
 
     @property
     def staff(self):
-        return self.role is Roles.STAFF
+        return Roles.STAFF in self.role
 
     @property
     def admin(self):
-        return self.role is Roles.ADMIN
+        return Roles.ADMIN in self.role
 
     @property
     def purple(self):
@@ -177,11 +179,11 @@ class ChatMessage(str):
 
     @property
     def system(self):
-        return self.role is Roles.SYSTEM
+        return Roles.SYSTEM in self.role
 
     @property
     def logged_in(self):
-        return self.green or self.purple or self.janitor or self.pro
+        return self.green or self.purple
 
     @property
     def ip_address(self):
@@ -193,10 +195,10 @@ class ChatMessage(str):
         prefix = ""
         if self.purple:
             prefix += "@"
-        if self.pro:
-            prefix += "✡"
         if self.owner:
             prefix += "👑"
+        if self.pro:
+            prefix += "✡"
         if self.janitor:
             prefix += "🧹"
         if self.donor:


### PR DESCRIPTION
Currently when you listen to the chat and get back a ChatMessage there is no way to see if the writer of the message is the room owner, even though it is possible to read this from the options that get delivered by the socket.
Solution: Add owner to roles in ChatMessage

Apart from that currently the api allows only one of these roles to be True for the writer of a message because of the from_options in Roles
```python
    def from_options(cls, options):
        user = "profile" in options
        if user:
            if "admin" in options:
                return cls.ADMIN
            if "staff" in options:
                return cls.STAFF
            if "owner" in options:
                return cls.OWNER
            if "janitor" in options:
                return cls.JANITOR
            if "pro" in options:
                return cls.PRO
            if "donator" in options:
                return cls.DONOR
            if "user" in options:
                return cls.USER
        else:
            if "admin" in options:
                return cls.SYSTEM
            if "staff" in options:
                return cls.SYSTEM
        return cls.WHITE
```
Previously the role "janitor" was below the role "pro". In My opinion that is a bad idea since janitor is a more important role for a room than pro. Because of this i changed the order of "janitor" and "pro", so pro users can actually be recognized as janitors in messages. (Also i put owner above janitor in this case)
A more longterm solution maybe would be to rework this so every possible role a user can have can also be delivered in ChatMessage, since currently it only gives back the highest role. 