### PR TITLE
Pin autobahn release to 19.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-autobahn
+autobahn==19.3.3
 requests
 orjson


### PR DESCRIPTION
A regression currently prevents use of volapi with an autobahn release newer than 19.3.3.

Let's pin the autobahn release until the regression is fixed. I don't know enough about autobahn to make an issue though.

Anyway -- fixes #11 for now.